### PR TITLE
Add new freature, disable IME

### DIFF
--- a/BetterWindow/BetterWindow.cpp
+++ b/BetterWindow/BetterWindow.cpp
@@ -14,6 +14,10 @@ void BetterWindow::OnLoad() {
 	auto_mode->SetComment("Auto block input when out of focus.");
 	auto_mode->SetDefaultBoolean(true);
 
+	disable_ime = GetConfig()->GetProperty("Mode", "DisableIME");
+	disable_ime->SetComment("Disable ingame IME. Restart game to apply it.");
+	disable_ime->SetDefaultBoolean(true);
+
 	hot_key = GetConfig()->GetProperty("Mode", "HotKey");
 	hot_key->SetComment("Hot key to block input forcibly.");
 	hot_key->SetDefaultKey(CKKEY_F4);
@@ -24,6 +28,16 @@ void BetterWindow::OnLoad() {
 	tip_lable->SetSize(Vx2DVector(1.0f, 0.0353f));
 	tip_lable->SetAlignment(ALIGN_CENTER);
 	tip_lable->SetText("INPUT BLOCKED");
+
+	if (disable_ime->GetBoolean()) {
+		// Get input context for backup. 
+		HIMC m_hImc = ImmGetContext(m_window);
+		// Remove association the testing 
+		if (m_hImc)
+			ImmAssociateContext(m_window, NULL);
+		// Release input context
+		ImmReleaseContext(m_window, m_hImc);
+	}
 }
 
 void BetterWindow::OnProcess() {

--- a/BetterWindow/BetterWindow.h
+++ b/BetterWindow/BetterWindow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Windows.h>
+#include <imm.h>
 #include <memory>
 #include <BML/BMLAll.h>
 
@@ -26,6 +28,7 @@ private:
 	InputHook* m_im;
 	IProperty* auto_mode;
 	IProperty* hot_key;
+	IProperty* disable_ime;
 	bool key_to_block = false;
 	std::unique_ptr<BGui::Label> tip_lable;
 };


### PR DESCRIPTION
Add a new feature to prevent the following problem:
![图片](https://user-images.githubusercontent.com/13994767/165299765-c59f097e-bc85-4a97-b0ae-4200651a5bfa.png)

It only can be applied when starting the game, or maybe I did not find a proper switch method.  
And I know this is a sub-function of your DebugMod4Ballance. So if this PR is not proper, just close it.